### PR TITLE
scx_lavd: Revise load-balancing conditions

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -78,12 +78,9 @@ int plan_x_cpdom_migration(void)
 		}
 
 		/*
-		 * Use avg_util_sum when mig_delta_pct is set, otherwise use cur_util_sum.
+		 * Use avg_util_sum for stable load balancing decisions.
 		 */
-		if (mig_delta_pct > 0)
-			util = (cpdomc->avg_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
-		else
-			util = (cpdomc->cur_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
+		util = (cpdomc->avg_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
 		qlen = cpdomc->nr_queued_task;
 		qlen_invr = (qlen << (LAVD_SHIFT * 3)) / cpdomc->cap_sum_active_cpus;
 		cpdomc->load_invr = util + qlen_invr;

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -18,6 +18,7 @@
 
 
 extern const volatile u8	mig_delta_pct;
+extern const volatile u8	lb_low_util_pct;
 
 u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_load_invr, int nz_qlen)
 {
@@ -54,6 +55,14 @@ int plan_x_cpdom_migration(void)
 	 * tasks to the powerful compute domains. This helps to maintain high
 	 * throughput when the system is overloaded.
 	 */
+
+	/*
+	 * When system utilization is low, periodic load balancing across
+	 * LLC domains is unnecessary since there is plenty of idle capacity.
+	 */
+	if (lb_low_util_pct > 0 &&
+	    sys_stat.avg_util_wall < ((u64)lb_low_util_pct << LAVD_SHIFT) / 100)
+		goto reset_and_skip_lb;
 
 	/*
 	 * Calculate scaled load for each active compute domain.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -219,6 +219,12 @@ const volatile u64	slice_max_ns = LAVD_SLICE_MAX_NS_DFL;
 const volatile u8	mig_delta_pct = 0;
 
 /*
+ * Skip periodic load balancing when average system utilization is below this
+ * percentage. 0 = disabled. Default: 25.
+ */
+const volatile u8	lb_low_util_pct = 25;
+
+/*
  * Slice time for all tasks when pinned tasks are running on the CPU.
  * When this is set (non-zero), pinned tasks always use per-CPU DSQs and
  * the dispatch logic compares vtimes across DSQs.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -225,6 +225,13 @@ const volatile u8	mig_delta_pct = 0;
 const volatile u8	lb_low_util_pct = 25;
 
 /*
+ * Bypass deadline-based scheduling and dispatch directly to local DSQ
+ * when average system utilization is below this percentage.
+ * 0 = disabled. Default: 10.
+ */
+const volatile u8	lb_local_dsq_util_pct = 10;
+
+/*
  * Slice time for all tasks when pinned tasks are running on the CPU.
  * When this is set (non-zero), pinned tasks always use per-CPU DSQs and
  * the dispatch logic compares vtimes across DSQs.
@@ -788,7 +795,9 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * When pinned_slice_ns is enabled, pinned tasks always use per-CPU DSQ
 	 * to enable vtime comparison across DSQs during dispatch.
 	 */
-	if (is_idle && !queued_on_cpu(cpuc)) {
+	if ((is_idle && !queued_on_cpu(cpuc)) ||
+	    (lb_local_dsq_util_pct > 0 &&
+	     sys_stat.avg_util_wall < ((u64)lb_local_dsq_util_pct << LAVD_SHIFT) / 100)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, p->scx.slice,
 				   enq_flags);
 	} else {

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -145,6 +145,16 @@ struct Opts {
     #[clap(long = "lb-low-util-pct", default_value = "25", value_parser=Opts::lb_low_util_pct_range)]
     lb_low_util_pct: u8,
 
+    /// Low utilization threshold percentage (0-100) for bypassing deadline
+    /// scheduling. When set to a non-zero value, tasks are dispatched directly
+    /// to the local DSQ (FIFO) instead of using deadline-based ordering when
+    /// average system utilization is below this percentage. The threshold is
+    /// calculated as: avg_util < (lb-local-dsq-util-pct << 10) / 100.
+    /// Default is 10 (bypass deadline scheduling below 10% utilization).
+    /// Set to 0 to disable. Set to 100 to always bypass deadline scheduling.
+    #[clap(long = "lb-local-dsq-util-pct", default_value = "10", value_parser=Opts::lb_local_dsq_util_pct_range)]
+    lb_local_dsq_util_pct: u8,
+
     /// Slice duration in microseconds to use for all tasks when pinned tasks
     /// are running on a CPU. Must be between slice-min-us and slice-max-us.
     /// When this option is enabled, pinned tasks are always enqueued to per-CPU DSQs
@@ -385,6 +395,10 @@ impl Opts {
     }
 
     fn lb_low_util_pct_range(s: &str) -> Result<u8, String> {
+        number_range(s, 0, 100)
+    }
+
+    fn lb_local_dsq_util_pct_range(s: &str) -> Result<u8, String> {
         number_range(s, 0, 100)
     }
 }
@@ -660,6 +674,7 @@ impl<'a> Scheduler<'a> {
         rodata.preempt_shift = opts.preempt_shift;
         rodata.mig_delta_pct = opts.mig_delta_pct;
         rodata.lb_low_util_pct = opts.lb_low_util_pct;
+        rodata.lb_local_dsq_util_pct = opts.lb_local_dsq_util_pct;
         rodata.no_use_em = opts.no_use_em as u8;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.no_slice_boost = opts.no_slice_boost;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -136,6 +136,15 @@ struct Opts {
     #[clap(long = "mig-delta-pct", default_value = "0", value_parser=Opts::mig_delta_pct_range)]
     mig_delta_pct: u8,
 
+    /// Low utilization threshold percentage (0-100) for periodic load balancing.
+    /// When set to a non-zero value, periodic load balancing is skipped when
+    /// average system utilization is below this percentage. The threshold is
+    /// calculated as: avg_util < (lb-low-util-pct << 10) / 100.
+    /// Default is 25 (skip periodic LB below 25% utilization).
+    /// Set to 0 to disable. Set to 100 to always skip periodic LB.
+    #[clap(long = "lb-low-util-pct", default_value = "25", value_parser=Opts::lb_low_util_pct_range)]
+    lb_low_util_pct: u8,
+
     /// Slice duration in microseconds to use for all tasks when pinned tasks
     /// are running on a CPU. Must be between slice-min-us and slice-max-us.
     /// When this option is enabled, pinned tasks are always enqueued to per-CPU DSQs
@@ -372,6 +381,10 @@ impl Opts {
     }
 
     fn mig_delta_pct_range(s: &str) -> Result<u8, String> {
+        number_range(s, 0, 100)
+    }
+
+    fn lb_low_util_pct_range(s: &str) -> Result<u8, String> {
         number_range(s, 0, 100)
     }
 }
@@ -646,6 +659,7 @@ impl<'a> Scheduler<'a> {
         rodata.pinned_slice_ns = opts.pinned_slice_us.map(|v| v * 1000).unwrap_or(0);
         rodata.preempt_shift = opts.preempt_shift;
         rodata.mig_delta_pct = opts.mig_delta_pct;
+        rodata.lb_low_util_pct = opts.lb_low_util_pct;
         rodata.no_use_em = opts.no_use_em as u8;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.no_slice_boost = opts.no_slice_boost;


### PR DESCRIPTION
LAVD's periodic load balancer runs unconditionally even when the system is lightly loaded, and balancing provides no benefit. This wastes CPU cycles and can cause unnecessary task migrations that hurt cache locality.

This series makes load balancing more selective by skipping it when the system is idle enough, and by simplifying the dispatch path at very low utilization where deadline ordering adds overhead without benefit. Task stealing at ops.dispatch() and task migration at ops.select_cpu() remain active for work conservation and handling bursty workloads.

Two new tunable command line options are introduced:

* --lb-low-util-pct (default 25): skip periodic LB below this utilization percentage
* --lb-local-dsq-util-pct (default 10): bypass deadline scheduling and use FIFO local DSQ below this utilization percentage